### PR TITLE
exit code as 1 when find conflicts

### DIFF
--- a/django_migration_checker/cli/find_conflicts.py
+++ b/django_migration_checker/cli/find_conflicts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 import argparse
 
 from django_migration_checker import get_conflicts
@@ -19,5 +20,6 @@ def main():
     conflicts = get_conflicts(args.apps_dir)
     if conflicts:
         print(conflicts)
+        sys.exit(1)
     else:
         print('No conflicts detected.')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ class TestFindMigrationsCliChecker(unittest.TestCase):
     def test_cli_passes_args(self, m_parse_args, m_get_conflicts):
         m_parse_args.return_value = self.valid_parsed_args
 
-        find_conflicts.main()
+        self.assertRaises(SystemExit, find_conflicts.main)
 
         m_get_conflicts.assert_called_with(self.apps_dir)
 


### PR DESCRIPTION
Thanks for the great repo first. 

For general case, we need to use the checker to find out the conflict and alert user to fix it. For shell script, it's better to exit with none zero code for identify the abnormal status