### PR TITLE
Fix error on double quote and multiple dependencies

### DIFF
--- a/django_migration_checker/base.py
+++ b/django_migration_checker/base.py
@@ -17,7 +17,7 @@ def extract_list(name, content):
         return []
 
     match_iter = re.finditer(
-        r"""\((['"])([^']+)\1,\s*(['"])([^_][^']+)\3\)""",
+        r"""\((['"])([^'"]+)\1,\s*(['"])([^_][^'"]+)\3\)""",
         raw_list,
         flags=re.VERBOSE
     )

--- a/tests/test_extract_list.py
+++ b/tests/test_extract_list.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+import sys
+import unittest
+
+from django_migration_checker.base import extract_list
+
+
+class TestExtractList(unittest.TestCase):
+    def test_basic_single_quote(self):
+        content = """
+            dependencies = [
+                ('llamas', '0001_one'),
+            ]
+        """
+        assert [('llamas', '0001_one')] == extract_list('dependencies', content)
+
+    def test_basic_double_quote(self):
+        content = """
+            dependencies = [
+                ("llamas", "0001_one"),
+            ]
+        """
+        assert [('llamas', '0001_one')] == extract_list('dependencies', content)
+
+    def test_basic_compact_style(self):
+        content = """
+            dependencies=[('llamas','0001_one')]
+        """
+        assert [('llamas', '0001_one')] == extract_list('dependencies', content)
+
+    def test_multi_dependencies_single_quote(self):
+        content = """
+            dependencies = [
+                ('llamas', '0001_one'),
+                ('llamas', '0002_two'),
+                ('llamas', '0003_three'),
+            ]
+        """
+        assert [
+                   ('llamas', '0001_one'),
+                   ('llamas', '0002_two'),
+                   ('llamas', '0003_three'),
+               ] == extract_list('dependencies', content)
+
+    def test_multi_dependencies_double_quote(self):
+        content = """
+            dependencies = [
+                ("llamas", "0001_one"),
+                ("llamas", "0002_two"),
+                ("llamas", "0003_three"),
+            ]
+        """
+        assert [
+                   ('llamas', '0001_one'),
+                   ('llamas', '0002_two'),
+                   ('llamas', '0003_three'),
+               ] == extract_list('dependencies', content)
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())


### PR DESCRIPTION
- update the reg exp about the ending double quote
- add unit-test for extract-list

Original logic can't handle the double quote & multiple lines style
```python
            dependencies = [
                ("llamas", "0001_one"),
                ("llamas", "0002_two"),
                ("llamas", "0003_three"),
            ]
```